### PR TITLE
fix: increase color contrast in footer for accessible text

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -212,7 +212,7 @@ main {
 
 footer {
   margin-top: 2rem;
-  color: #888;
+  color: #767676;
   font-size: 0.9rem;
   text-align: center;
 }


### PR DESCRIPTION
`#888888` only has 3.54:1 contrast against `#ffffff`: https://webaim.org/resources/contrastchecker/?fcolor=888888&bcolor=FFFFFF. That's a bit below the AA requirement of 4.5:1

`#767676` is the lightest hex gray that has an accessible contrast against white at 4.54:1. https://webaim.org/resources/contrastchecker/?fcolor=767676&bcolor=FFFFFF