### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "simple-git-hooks": {
     "pre-commit": "npx nano-staged"
   },
-  "packageManager": "pnpm@10.21.0",
+  "packageManager": "pnpm@11.1.2",
   "nano-staged": {
     "*.{js,ts,mjs,cjs,json,.*rc}": [
       "npx eslint --fix"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,7 @@
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-onlyBuiltDependencies:
-  - sharp
-  - simple-git-hooks
-
+allowBuilds:
+  '@parcel/watcher': false
+  esbuild: false
+  sharp: true
+  simple-git-hooks: true
+  unrs-resolver: false
+  vue-demi: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`